### PR TITLE
fix wrong level in season1 tracks

### DIFF
--- a/web/client/assets/data/season1/tracks.js
+++ b/web/client/assets/data/season1/tracks.js
@@ -2,7 +2,7 @@ const speed = [
   {
     id: 'abyss_R02',
     name: '深海 崎嶇海峽',
-    level: 2
+    level: 4
   },
   {
     id: 'god_R02',


### PR DESCRIPTION
I think that the level of "深海 崎嶇海峽" should be 4 not 2.